### PR TITLE
'elder scroll' script

### DIFF
--- a/chromeshack.css
+++ b/chromeshack.css
@@ -206,7 +206,7 @@ span.newcommenthighlighter_bluetext {
     -webkit-border-radius: 4px;
     background-image: -webkit-gradient(linear, 0 100%, 100% 0, color-stop(.25, rgba(255, 255, 255, .4)), color-stop(.25, transparent), color-stop(.5, transparent), color-stop(.5, rgba(255, 255, 255, .4)), color-stop(.75, rgba(255, 255, 255, .4)), color-stop(.75, transparent), to(transparent));
     -webkit-background-size: 25px 25px;
-    -webkit-box-shadow: inset 0 2px 4px rgba(255, 255, 255, 0.3), inset 0 -2px 3px rgba(0, 0, 0, 0.4)
+    -webkit-box-shadow: inset 0 2px 4px rgba(255, 255, 255, 0.3), inset 0 -2px 3px rgba(0, 0, 0, 0.4);
 }
 
 .countdown-doom {
@@ -221,13 +221,46 @@ span.newcommenthighlighter_bluetext {
 
 /* get post */
 div.getPost {
-	padding: 3px 0 25px 0;
-	margin-bottom: 3px;
-	border: 1px #94FFB9 solid;
-	height: 1%;
-	position: relative;
+    padding: 3px 0 25px 0;
+    margin-bottom: 3px;
+    border: 1px #94FFB9 solid;
+    height: 1%;
+    position: relative;
 }
 
 div.getPost div.refresh, div.getPost div.reply, div.getPost div.postmeta a.closepost {display: none;}
 
 div.getPost span.user a {text-decoration: none;}
+
+/* elder scroll */
+#elderscroll-message {
+    -webkit-border-radius: 5px;
+    color: #000 !important;
+    background: #FFF !important;
+    font-size: 1.5em !important;
+    height: 25px;
+    width: 300px;
+    text-align: center;
+    margin-left: auto !important;
+    margin-right: auto !important;
+    padding-top: 5px !important;
+}
+
+
+#shackLogo {
+    width: 18px;
+    height: 18px;
+    margin-left: 10px;
+    display: inline-block !important;
+    background-image: url(chrome-extension://mcnpepegfcikofcogenpncheiohblnpp/shack.png);
+    -webkit-animation-name: elderscroll-rotate;
+    -webkit-animation-timing-function: ease-in-out;
+    -webkit-animation-iteration-count: infinite;
+    -webkit-animation-duration: 1.5s;
+}
+
+@-webkit-keyframes elderscroll-rotate {
+    0% { -webkit-transform: rotate(-20deg); }
+    50% { -webkit-transform: rotate(20deg); }
+    100% { -webkit-transform: rotate(-20deg); }
+}

--- a/common.js
+++ b/common.js
@@ -8,6 +8,19 @@ function getDescendentByTagAndClassName(parent, tag, class_name)
     }
 }
 
+function getDescendentsByTagAndClassName(parent, tag, class_name) 
+{
+    var descendents = parent.getElementsByTagName(tag);
+    var descArray = new Array();
+    for (var i = 0; i < descendents.length; i++) 
+    {
+        if (descendents[i].className.indexOf(class_name) == 0) 
+            descArray.push(descendents[i]);
+    }
+
+    return descArray;
+}
+
 function stripHtml(html)
 {
     return String(html).replace(/(<([^>]+)>)/ig, '');

--- a/manifest.json
+++ b/manifest.json
@@ -36,6 +36,7 @@
             "scripts/local_timestamp.js",
             "scripts/expiration_watcher.js",
             "scripts/getpost.js",
+            "scripts/elder_scroll.js",
             "chromeshack_posts.js",
             "default_settings.js",
             "settings.js"

--- a/options.html
+++ b/options.html
@@ -98,6 +98,10 @@
             <input type="checkbox" class="script_check" id="getpost" />
             <label for="getpost">Get Post</label>
         </h2>
+        <h2>
+            <input type="checkbox" class="script_check" id="elder_scroll" />
+            <label for="elder_scroll">Elder Scroll</label>
+        </h2>
         <div>
             <button onclick="saveOptions()">Save</button>
             <button onclick="loadOptions()">Reset</button>

--- a/scripts/elder_scroll.js
+++ b/scripts/elder_scroll.js
@@ -1,0 +1,182 @@
+/**
+*   Originally authored by indosaurus, re-written for chromeshack.
+*
+*   Upon reaching the bottom of the page the next page of posts will be loaded and appended to the
+*   threads.
+*
+*   It's named "elder scroll" because it's loading /[older]/ posts when you scroll HAHAHAAHAH *gun*
+*
+**/
+
+/*  TODO:
+*       let pxToLoadNew be set by the user?
+*       check if new thread ID matches an existing thread ID -> don't load it.
+*       appending new threads is too slow (see end of loadNextPage function)
+*/
+
+settingsLoadedEvent.addHandler(function()
+{
+    if (getSetting("enabled_scripts").contains("elder_scroll"))
+    {       
+        ElderScroll = 
+        {
+            pxToLoadNew: 500,
+            isLoadingNew: false,
+            divLoadingInfo: null,
+
+            install: function()
+            {
+                if (ElderScroll.getDivNavigation() != null)
+                {
+                    window.addEventListener('scroll', ElderScroll.reachedBottom, false);
+                    window.addEventListener('resize', ElderScroll.reachedBottom, false);
+                }
+            },
+            
+            createDivMessage: function(text, addLoadingAnimation)
+            {
+                var divLoadingInfo = document.createElement('div');
+                divLoadingInfo.id = 'elderscroll-message';
+                divLoadingInfo.appendChild(document.createTextNode(text));
+                
+                //divLoadingInfo.innerText = text;
+                
+                if (addLoadingAnimation)
+                {
+                    var shackLogo = document.createElement('div');
+                    shackLogo.id = 'shackLogo';
+                    //.setAttribute("border", "100");
+                    divLoadingInfo.appendChild(shackLogo);
+                    
+                }
+                
+                return divLoadingInfo;
+            },
+            
+            getDivMessage: function(parentNode)
+            {
+                return document.getElementById('elderscroll-message');
+            },
+
+            getDivThreadContainer: function()
+            {
+                return document.getElementById('chatty_comments_wrap');
+            },
+
+            getDivThreads: function()
+            {
+                return getDescendentByTagAndClassName(ElderScroll.getDivThreadContainer(), 'div', 'threads');  
+            },
+
+            getDivNavigation: function()
+            {
+                return getDescendentsByTagAndClassName(ElderScroll.getDivThreadContainer(), 'div', 'pagenavigation');
+            },
+
+            reachedBottom: function()
+            {
+                if (!ElderScroll.isLoadingNew)
+                {
+                    var divThreads = ElderScroll.getDivThreads();
+
+                    // top of div + its height
+                    var divBottomPos = divThreads.offsetTop + divThreads.offsetHeight;
+                    
+                    // top of viewport + viewport height
+                    var viewPortBottomPos = window.pageYOffset + window.innerHeight;
+
+                    // 500 -> pixels at which we have left to load in new threads.
+                    if ((divBottomPos - ElderScroll.pxToLoadNew) <= viewPortBottomPos)
+                    {
+                        if (ElderScroll.nextPageExists())
+                        {
+                            ElderScroll.loadNextPage();
+                        } else {
+                            divThreads.appendChild(ElderScroll.createDivMessage('No more threads to load.', false));
+
+                            // lazy
+                            ElderScroll.isLoadingNew = true;
+                        }
+                    }
+                }
+            },
+
+            getNextPage: function()
+            {
+                var divThreadContainer = ElderScroll.getDivThreadContainer();
+                var currentPage = getDescendentByTagAndClassName(divThreadContainer, 'a', 'selected_page');
+
+                return parseInt(currentPage.innerHTML) + 1;
+            },
+
+            nextPageExists: function()
+            {
+                var divNavigation = ElderScroll.getDivNavigation();
+                var nextButton = divNavigation[0].lastChild;
+
+                // <a> tag = more pages wooo!
+                // <span> tag = no more *sad panda*
+                return (nextButton.tagName.toLowerCase() == 'a')
+            },
+
+            loadNextPage: function(pageNum)
+            {
+                ElderScroll.isLoadingNew = true;
+
+                var divThreads = ElderScroll.getDivThreads();
+                divThreads.appendChild(ElderScroll.createDivMessage('Loading new posts...', true));
+                
+                var nextPageURL = "http://www.shacknews.com/chatty?page=" + ElderScroll.getNextPage();
+              
+                getUrl(nextPageURL, function(response)
+                {
+                    divThreads.removeChild(ElderScroll.getDivMessage());
+                    
+                    if (response.status == 200 && response.statusText.toLowerCase() == 'ok')
+                    {
+                        // a _bad_ way of doing this...
+                        var divResponse = document.createElement('div');
+                        divResponse.innerHTML = response.responseText;
+
+                        var newDivThreadContainer = getDescendentByTagAndClassName(divResponse, 'div', 'commentsblock');
+                        var newDivNavigation = getDescendentByTagAndClassName(newDivThreadContainer, 'div', 'pagenavigation');
+                        var newDivThreads = getDescendentByTagAndClassName(newDivThreadContainer, 'div', 'threads');
+
+                        var fragment = document.createDocumentFragment();
+
+                        for (var i = 0; i < newDivThreads.childNodes.length; ++i)
+                        {
+                            fragment.appendChild(newDivThreads.childNodes[i].cloneNode(true));
+                        }
+                        
+                        /**
+                        *   TODO: Speed up this really slow operation somehow.
+                        *      This is probably due to the other content scripts all firing.  The
+                        *      more the user has enabled, the slower this entire operation is.
+                        **/
+                        divThreads.appendChild(fragment.cloneNode(true));
+                        
+                        /** 
+                        * Just appending the new threads and their parent container is much faster,
+                        * but the other content scripts won't be able to modify the new threads as
+                        * they're no longer direct children of the original thread div.
+                        *
+                        * divThreads.appendChild(newDivThreads);
+                        **/
+
+                        // update pageNavigation divs
+                        var divThreadContainer = ElderScroll.getDivThreadContainer();
+                        var divNavigation = ElderScroll.getDivNavigation();
+                        divNavigation[0].parentNode.replaceChild(newDivNavigation.cloneNode(true), divNavigation[0]);
+                        divNavigation[1].parentNode.replaceChild(newDivNavigation.cloneNode(true), divNavigation[1]);         
+
+                        ElderScroll.isLoadingNew = false;
+                    } else {
+                        divThreads.appendChild(ElderScroll.createDivMessage('Something broke.', false));
+                    }
+                });   
+            }
+        }
+        ElderScroll.install();
+    }
+});


### PR DESCRIPTION
Gets the next page of (_elder_) threads when you _scroll_ past a certain threshold (_elder scroll_... geddit? hurrrrr).  New threads are appended to the current list of threads. 

Appending the new threads can _really_ chug depending on how many other content scripts the user has enabled.  I'm not as well versed in DOM stuff as you guys are, so please let me know if you know of a better way of doing this.
