### PR TITLE
nws: Fixed open all in incognito losing scroll position.

### DIFF
--- a/release_notes.html
+++ b/release_notes.html
@@ -4,6 +4,10 @@
     </head>
     <body>
         <h1>Chrome Shack Release Notes</h1>
+        <h2>Version 1.37</h2>
+        <ul>
+            <li>Fix nws enhancements when opening all links to new incognito window</li>
+        </ul>
         <h2>Version 1.36</h2>
         <ul>
             <li>Support gfycat in image loader script.</li>

--- a/scripts/nws_incognito.js
+++ b/scripts/nws_incognito.js
@@ -42,6 +42,7 @@ settingsLoadedEvent.addHandler(function() {
                                             chrome.runtime.sendMessage({name: "launchIncognito", value: allLinks[i]});
                                         }
                                     });
+                                return false;
                                 }).append($('<br/><br/>')));
                             }
                         }


### PR DESCRIPTION
Clicking the "Open All (Incognito)" link would jump to the top of the page because the click handler doesn't `return false;` 

Example: http://www.shacknews.com/chatty?id=31735769#item_31735769
