### PR TITLE
Add user dropdown to collapsed header; support WinChatty NuSearch.

### DIFF
--- a/options.html
+++ b/options.html
@@ -155,6 +155,13 @@
             <a href="https://winchatty.com/v2/notifications/ui/configure" target="_blank" style="margin-left: 10px;">Change notification options...</a>
         </div>
         <div>
+            <h2>
+                <input type="checkbox" class="script_check" id="use_winchatty_search" />
+                <label for="use_winchatty_search">Use WinChatty NuSearch</label>
+            </h2>
+            <p>Applies to the "posts", "vanity search", and "parent author search" links in the user dropdown.</p>
+        </div>
+        <div>
             <br/>
             <button id="save_options">Save</button>
             <button id="load_options">Reset</button>

--- a/scripts/shack-userpopup.user.js
+++ b/scripts/shack-userpopup.user.js
@@ -359,9 +359,20 @@
 			}
 		
 			// Create menu items and add them to ulUser
-			ulUser.appendChild(createListItem(your + ' Posts', 'http://www.shacknews.com/user/' + username + '/posts')); 		
-			ulUser.appendChild(createListItem(vanitySearch, 'http://www.shacknews.com/search?chatty=1&type=4&chatty_term=' + username + '&chatty_user=&chatty_author=&chatty_filter=all&result_sort=postdate_desc'));
-			ulUser.appendChild(createListItem(parentAuthor, 'http://www.shacknews.com/search?chatty=1&type=4&chatty_term=&chatty_user=&chatty_author=' + username + '&chatty_filter=all&result_sort=postdate_desc', 'userDropdown-separator'));
+			var postsUrl = getSetting("enabled_scripts").contains("use_winchatty_search") 
+				? 'https://winchatty.com/nusearch?a=' + username
+				: 'http://www.shacknews.com/user/' + username + '/posts';
+			ulUser.appendChild(createListItem(your + ' Posts', postsUrl));
+
+			var vanityUrl = getSetting("enabled_scripts").contains("use_winchatty_search") 
+				? 'https://winchatty.com/nusearch?q=' + username
+				: 'http://www.shacknews.com/search?chatty=1&type=4&chatty_term=' + username + '&chatty_user=&chatty_author=&chatty_filter=all&result_sort=postdate_desc';
+			ulUser.appendChild(createListItem(vanitySearch, vanityUrl));
+
+			var repliesUrl = getSetting("enabled_scripts").contains("use_winchatty_search") 
+				? 'https://winchatty.com/nusearch?pa=' + username
+				: 'http://www.shacknews.com/search?chatty=1&type=4&chatty_term=&chatty_user=&chatty_author=' + username + '&chatty_filter=all&result_sort=postdate_desc';
+			ulUser.appendChild(createListItem(parentAuthor, repliesUrl, 'userDropdown-separator'));
 
 			// Include reference to person actually sitting behind the keyboard in all links to lol page
 			var actualUser = '&user=' + encodeURIComponent(getShackUsername());


### PR DESCRIPTION
User dropdown button is now available in both the expanded header shown when the user is scrolled to the top of the page, as well as the collapsed header shown when the user scrolls down.  An option to use WinChatty NuSearch instead of the Shacknews comment search has been added.
