### PR TITLE
remove filtered post instead of hide

### DIFF
--- a/scripts/custom_user_filters.js
+++ b/scripts/custom_user_filters.js
@@ -38,7 +38,7 @@
             var postDiv = postDivs[i];
             var postLi = postDiv.parentNode;
             if (postLi.tagName === 'LI') {
-                postLi.style.display = 'none';
+                postLi.parentNode.removeChild(postLi);
             }
         }
     }


### PR DESCRIPTION
When a post is hidden the a/z shortcut keys still silently navigate to the hidden post and through all its children.
